### PR TITLE
Guard upload size against footer sector

### DIFF
--- a/Sketchs/exeupload.ino
+++ b/Sketchs/exeupload.ino
@@ -293,7 +293,8 @@ void loop() {
 
   uint32_t fsize = rdU32LE(&hdr[4]);
   uint32_t fhash = rdU32LE(&hdr[8]);
-  if (fsize==0 || fsize>FLASH_SIZE) { Serial.println("SIZEERR"); return; }
+  // Last 4KB sector reserved for footer metadata.
+  if (fsize==0 || fsize>FOOTER_SECTOR_BASE) { Serial.println("SIZEERR"); return; }
 
   // Yalnızca dosyanın kapsadığı sektörleri sil
   uint32_t last = fsize - 1;


### PR DESCRIPTION
## Summary
- update exeupload sketch to reject payloads larger than the usable flash space
- document the reserved 4KB footer sector for maintainers

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db0f398ff08326bf69a56f747b6de4