### PR TITLE
Guard flash footer reservation

### DIFF
--- a/Scripts/exeSender.py
+++ b/Scripts/exeSender.py
@@ -3,6 +3,8 @@ import sys, struct, serial, time
 
 FNV_OFFSET = 0x811C9DC5
 FNV_PRIME  = 0x01000193
+FLASH_SIZE = 2 * 1024 * 1024
+FOOTER_RESERVATION = 4096
 
 def fnv1a(data: bytes) -> int:
     h = FNV_OFFSET
@@ -41,8 +43,11 @@ def main():
     size = len(data)
     if size == 0:
         print("Empty file"); sys.exit(1)
-    if size > 2*1024*1024:
-        print("Too big for 2MB flash"); sys.exit(1)
+    max_payload = FLASH_SIZE - FOOTER_RESERVATION
+    if size > max_payload:
+        raise ValueError(
+            f"Payload of {size} bytes exceeds usable flash capacity of {max_payload} bytes; the last 4KB are reserved for the footer sector."
+        )
 
     h = fnv1a(data)
 


### PR DESCRIPTION
## Summary
- define explicit flash size and footer reservation constants used by the sender script
- raise an error when the payload exceeds usable flash capacity, explaining the reserved footer sector

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68db10ef29f08326b9fa6fa3d7d1f5d4