### PR TITLE
Disable watchdog at start of setup

### DIFF
--- a/Sketchs/exupdater.ino
+++ b/Sketchs/exupdater.ino
@@ -205,6 +205,7 @@ void postUpdateCleanup() {
 }
 
 void setup() {
+  wdt_disable();
   Serial.begin(115200);
   SPI.begin();
 


### PR DESCRIPTION
## Summary
- disable the watchdog at the start of `setup()` so a previous bootloader trigger does not reset the board again

## Testing
- not run (hardware required)


------
https://chatgpt.com/codex/tasks/task_e_68e309e25e448326a919a7c8aa9c2515